### PR TITLE
Twine Importer GUI

### DIFF
--- a/Project/Assets/Editor/Twine Importer.meta
+++ b/Project/Assets/Editor/Twine Importer.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 3734c63bb02dc494683f32d7d6aa91ca
+folderAsset: yes
+timeCreated: 1476305987
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project/Assets/Editor/Twine Importer/TwineImporterUI.cs
+++ b/Project/Assets/Editor/Twine Importer/TwineImporterUI.cs
@@ -1,6 +1,8 @@
 ﻿using UnityEngine;
 using UnityEditor;
 using System.Collections;
+using System.IO;
+using System;
 
 /// <summary>
 /// Defines the Import Twine window and a few contextual menu actions to trigger import.
@@ -9,13 +11,20 @@ public class TwineImporterUI : EditorWindow {
 
 	public TextAsset targetFile;
 
+	/// <summary>
+	/// Defines the "Import Twine Data" menu item and its action.
+	/// If triggered from a context menu on an HTML asset, the asset is automatically selected for import.
+	/// </summary>
 	[MenuItem("Assets/Import Twine Data...")]
 	static void ShowTwineImportWindow () {
 
 		// if triggered while a text asset is selected, populate it as the target file
 		TextAsset selectedFile = null;
-		if (Selection.activeObject != null && Selection.activeObject.GetType () == typeof(TextAsset)) {
-			selectedFile = (TextAsset) Selection.activeObject;
+		if (Selection.activeObject != null) {
+			var filePath = AssetDatabase.GetAssetPath (Selection.activeObject);
+			if (Path.GetExtension (filePath) == "html") {
+				selectedFile = (TextAsset) Selection.activeObject;
+			}
 		}
 
 		// create and show window
@@ -23,16 +32,63 @@ public class TwineImporterUI : EditorWindow {
 		window.targetFile = selectedFile;
 	}
 
+	/// <summary>
+	/// Draws the GUI of the import window
+	/// </summary>
 	void OnGUI () {
 		GUILayout.Label ("Import Twine Data", EditorStyles.boldLabel);
 
-		// display info about the selected file
-		targetFile = (TextAsset) EditorGUILayout.ObjectField ("Selcted File:", targetFile, typeof(TextAsset), false);
+		GUILayout.BeginHorizontal ();
+		GUILayout.Label ("Twine File:");
 
-		// send it to importer
-		if (GUILayout.Button ("Import") && this.targetFile != null) {
-			SendToImporter (this.targetFile);
+		// button which selects a target file
+		var prompt = "Select File...";
+		if (targetFile != null) {
+			prompt = targetFile.name;
 		}
+		if (GUILayout.Button (prompt)) {
+			var fullPath = EditorUtility.OpenFilePanel ("Select File", "Assets/", "html");
+
+			// obnoxiously, the OpenFilePanel returns a full file path,
+			// and Unity will only play nice with a relative one so we must convert
+			var projectDirectory = Directory.GetParent (Application.dataPath).ToString ();
+			var relativePath = GetRelativePath (fullPath, projectDirectory);
+
+			// double check we'll have access to this file
+			if (relativePath.StartsWith ("Assets/")) {
+				this.targetFile = AssetDatabase.LoadAssetAtPath<TextAsset> (relativePath);
+			} else {
+				EditorUtility.DisplayDialog ("Can't Load Asset", "The file must be stored as part of your Unity project's assets.", "OK");
+			}
+		}
+
+		GUILayout.EndHorizontal ();
+
+		GUILayout.FlexibleSpace ();
+
+		// button to send to importer
+		GUI.enabled = (this.targetFile != null);
+		if (GUILayout.Button ("Import")) {
+			SendToImporter (this.targetFile);
+			this.Close ();
+		}
+	}
+
+	/// <summary>
+	/// Converts a absolute path to a relative path from some other folder
+	/// </summary>
+	/// <returns>A relative path with the `folder` as the base</returns>
+	/// <param name="filespec">The full path to a file inside of `folder`</param>
+	/// <param name="folder">The folder to act as the root for the new path</param>
+	private string GetRelativePath(string filespec, string folder) {
+		Uri pathUri = new Uri(filespec);
+		// Folders must end in a slash
+		if (!folder.EndsWith(Path.DirectorySeparatorChar.ToString()))
+		{
+			folder += Path.DirectorySeparatorChar;
+		}
+		Uri folderUri = new Uri(folder);
+		return Uri.UnescapeDataString(folderUri.MakeRelativeUri(pathUri).ToString().Replace('/', Path.DirectorySeparatorChar));
 	}
 
 	/// <summary>
@@ -40,7 +96,11 @@ public class TwineImporterUI : EditorWindow {
 	/// </summary>
 	/// <param name="filePath">The file path of the Twine html to be imported</param>
 	void SendToImporter (TextAsset file) {
-		// TwineImporter.Import (file);
+
+		// =======    Link to Importer     ==========
+		// 	TwineImporter.Import (file);
+		// ==========================================
+
 		Debug.Log ("Importing "+file.name+"...");
 	}
 

--- a/Project/Assets/Editor/Twine Importer/TwineImporterUI.cs
+++ b/Project/Assets/Editor/Twine Importer/TwineImporterUI.cs
@@ -1,0 +1,47 @@
+﻿using UnityEngine;
+using UnityEditor;
+using System.Collections;
+
+/// <summary>
+/// Defines the Import Twine window and a few contextual menu actions to trigger import.
+/// </summary>
+public class TwineImporterUI : EditorWindow {
+
+	public TextAsset targetFile;
+
+	[MenuItem("Assets/Import Twine Data...")]
+	static void ShowTwineImportWindow () {
+
+		// if triggered while a text asset is selected, populate it as the target file
+		TextAsset selectedFile = null;
+		if (Selection.activeObject != null && Selection.activeObject.GetType () == typeof(TextAsset)) {
+			selectedFile = (TextAsset) Selection.activeObject;
+		}
+
+		// create and show window
+		var window = EditorWindow.GetWindow<TwineImporterUI> ();
+		window.targetFile = selectedFile;
+	}
+
+	void OnGUI () {
+		GUILayout.Label ("Import Twine Data", EditorStyles.boldLabel);
+
+		// display info about the selected file
+		targetFile = (TextAsset) EditorGUILayout.ObjectField ("Selcted File:", targetFile, typeof(TextAsset), false);
+
+		// send it to importer
+		if (GUILayout.Button ("Import") && this.targetFile != null) {
+			SendToImporter (this.targetFile);
+		}
+	}
+
+	/// <summary>
+	/// Sends an html file to the Twine importer for input
+	/// </summary>
+	/// <param name="filePath">The file path of the Twine html to be imported</param>
+	void SendToImporter (TextAsset file) {
+		// TwineImporter.Import (file);
+		Debug.Log ("Importing "+file.name+"...");
+	}
+
+}

--- a/Project/Assets/Editor/Twine Importer/TwineImporterUI.cs.meta
+++ b/Project/Assets/Editor/Twine Importer/TwineImporterUI.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8d823ec8617a34ce08bbe79eacbaceef
+timeCreated: 1476306051
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This pull request adds in the GUI Window and Menu Items to interact with the (currently unlinked) Twine Importer.
### Additions
- **Menu Item:** _Assets/Import Twine Data..._ shows the Twine Import Window.
- **Twine Import Window** has labels and a button for selecting a file in your project assets for import. 
- Right clicking on a HTML asset in the asset browser and selecting "Import Twine Data..." will populate the window with that asset as the target (if applicable).
### Linking to Importer

`TwineImporterUI.SendToImporter(TextAsset)` is currently a stub. This method should simply forward its call to the associated `TwineImporter.Import(TextAsset)`, once such a module exists.
