### PR TITLE
Player Freeze API Move

### DIFF
--- a/Project/Assets/Prairie/Framework/Script/Interaction/AnnotationInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/AnnotationInteraction.cs
@@ -35,14 +35,15 @@ public class AnnotationInteraction : Interaction
     protected override void PerformAction()
     {
         Active = true;
-        //freeze the player when annotation is open
+
+		if (trigger.GetComponent<FirstPersonInteractor> () != null)
+			trigger.GetComponent<FirstPersonInteractor> ()?.SetIsFrozen (true);
     }
 
     void OnGUI()
     {
         if (Active)
         {
-            SetPlayerFrozen(true);
             //Allow the player to see and move the cursor (so they can scroll)
             Cursor.visible = true;
             Cursor.lockState = CursorLockMode.None;
@@ -93,7 +94,9 @@ public class AnnotationInteraction : Interaction
                 Active = false;
                 Cursor.visible = false;
                 Cursor.lockState = CursorLockMode.Locked;
-                SetPlayerFrozen(false);
+                
+				if (trigger.GetComponent<FirstPersonInteractor> () != null)
+					trigger.GetComponent<FirstPersonInteractor> ()?.SetIsFrozen (false);
             }
         }
     }

--- a/Project/Assets/Prairie/Framework/Script/Interaction/FirstPersonInteractor.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/FirstPersonInteractor.cs
@@ -86,4 +86,18 @@ public class FirstPersonInteractor : MonoBehaviour
 			return new List<Interaction> ();	// no interactions, empty list
 		}
 	}
+
+	// ====== Utility Functions ========
+
+	/// <summary>
+	/// Sets the player state to be locked if true, free to move if untrue.
+	/// </summary>
+	/// <param name="isFrozen">If <c>true</c>, the player can not move.</param>
+	public void SetIsFrozen(bool isFrozen)
+	{
+		this.GetComponent<UnityStandardAssets.Characters.FirstPerson.FirstPersonController>().enabled = !isFrozen;
+		this.enabled = !isFrozen;
+	}
+
+
 }

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Interaction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Interaction.cs
@@ -20,10 +20,4 @@ public abstract class Interaction : MonoBehaviour
 
 	protected abstract void PerformAction ();
 
-    protected void SetPlayerFrozen(bool isFrozen)
-    {
-        trigger.GetComponent<UnityStandardAssets.Characters.FirstPerson.FirstPersonController>().enabled = !isFrozen;
-        trigger.GetComponent<FirstPersonInteractor>().enabled = !isFrozen;
-    }
-
 }


### PR DESCRIPTION
This PR moves `Interaction.SetPlayerFrozen(bool)` to `FirstPersonInteractor.SetIsFrozen(bool)` and updates `AnnotationInteraction` to use the new API.
