### PR TITLE
Change onGUI box for TwineNodes to wrap text and display all body text

### DIFF
--- a/Project/Assets/Prairie/Framework/Script/Twine/TwineNode.cs
+++ b/Project/Assets/Prairie/Framework/Script/Twine/TwineNode.cs
@@ -20,12 +20,13 @@ public class TwineNode : MonoBehaviour {
 	{
 		if (this.enabled) 
 		{
-			Rect frame = new Rect (10, 10, Screen.width/3, Screen.height);
+			float frameWidth = Screen.width / 3;
+			Rect frame = new Rect (10, 10, frameWidth, Screen.height);
 
 			GUI.BeginGroup(frame);
 			GUIStyle style = GUI.skin.box;
 			style.wordWrap = true;
-			style.fixedWidth = Screen.width / 3;
+			style.fixedWidth = frameWidth;
 			GUILayout.Box (this.content, style);
 			GUI.EndGroup ();
 

--- a/Project/Assets/Prairie/Framework/Script/Twine/TwineNode.cs
+++ b/Project/Assets/Prairie/Framework/Script/Twine/TwineNode.cs
@@ -20,11 +20,15 @@ public class TwineNode : MonoBehaviour {
 	{
 		if (this.enabled) 
 		{
-			// Draw a GUI with the interaction
-			Rect frame = new Rect (Screen.width / 8, Screen.height / 8, Screen.width / 8, Screen.height / 8);
+			Rect frame = new Rect (10, 10, Screen.width/3, Screen.height);
+
 			GUI.BeginGroup(frame);
-			GUILayout.Box (this.content);
-			GUI.EndGroup();
+			GUIStyle style = GUI.skin.box;
+			style.wordWrap = true;
+			style.fixedWidth = Screen.width / 3;
+			GUILayout.Box (this.content, style);
+			GUI.EndGroup ();
+
 		}
 	}
 

--- a/Project/Assets/Prairie/Framework/Script/Twine/TwineNode.cs
+++ b/Project/Assets/Prairie/Framework/Script/Twine/TwineNode.cs
@@ -24,7 +24,7 @@ public class TwineNode : MonoBehaviour {
 			Rect frame = new Rect (10, 10, frameWidth, Screen.height);
 
 			GUI.BeginGroup(frame);
-			GUIStyle style = GUI.skin.box;
+			GUIStyle style = new GUIStyle(GUI.skin.box);
 			style.wordWrap = true;
 			style.fixedWidth = frameWidth;
 			GUILayout.Box (this.content, style);


### PR DESCRIPTION
The GUI box will be 10px away from the top and left side of the screen. It's width is 1/3 of the screen width, and its height is the whole screen (so it will still not show all the text if the text goes beyond that length -- in the future we should modify this to change text size).

I also enabled word wrap in the box's style.

(Closes #57)

**Todo still:** We still have to deal with finalizing the layout of where this text goes, etc. For now, this mostly just makes the text readable for our demos.