### PR TITLE
Refactoring Player, Prompt, and GUI drawing

### DIFF
--- a/Project/Assets/Prairie/Framework/Script/Interaction/AnnotationInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/AnnotationInteraction.cs
@@ -85,7 +85,11 @@ public class AnnotationInteraction : Interaction
     protected override void PerformAction()
     {
         active = true;
-		this.SetPlayerIsFrozen (true);
+		FirstPersonInteractor player = this.GetPlayer ();
+		if (player != null) {
+			player.SetCanMove (false);
+			player.SetDrawsGUI (false);
+		}
     }
 
     void OnGUI()
@@ -175,7 +179,11 @@ public class AnnotationInteraction : Interaction
                 Cursor.visible = false;
                 Cursor.lockState = CursorLockMode.Locked;
                 
-				this.SetPlayerIsFrozen (false);
+				FirstPersonInteractor player = this.GetPlayer ();
+				if (player != null) {
+					player.SetCanMove (true);
+					player.SetDrawsGUI (true);
+				}
             }
         }
     }

--- a/Project/Assets/Prairie/Framework/Script/Interaction/AnnotationInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/AnnotationInteraction.cs
@@ -115,6 +115,12 @@ public class AnnotationInteraction : Interaction
         }
     }
 
+    public void DrawSummary ()
+    {
+        // TODO: If a summary exists (and is enabled), draw it to the screen
+        // this function is in charge of checking whether or not it has a summary to draw
+    }
+
     /// <summary>
     /// Displays then annotation text and images
     /// </summary>

--- a/Project/Assets/Prairie/Framework/Script/Interaction/FirstPersonInteractor.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/FirstPersonInteractor.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using System.Collections.Generic;
+using UnityStandardAssets.Characters.FirstPerson;
 
 public class FirstPersonInteractor : MonoBehaviour
 {
@@ -54,14 +55,14 @@ public class FirstPersonInteractor : MonoBehaviour
 		if (this.highlightedObject != null)
 		{
 			// draw prompt on highlighted object
-			prompt = this.highlightedObject.GetComponent<Prompt> ();
+			Prompt prompt = this.highlightedObject.GetComponent<Prompt> ();
 			if (prompt != null)
 			{
 				prompt.DrawPrompt();
 			}
 
 			// draw potential stub on highlighted annotation object
-			annotation = this.highlightedObject.GetComponent<AnnotationInteraction> ();
+			AnnotationInteraction annotation = this.highlightedObject.GetComponent<AnnotationInteraction> ();
 			if (annotation != null)
 			{
 				annotation.DrawSummary();
@@ -90,7 +91,11 @@ public class FirstPersonInteractor : MonoBehaviour
 
 	private void AttemptInteract ()
 	{
-		foreach (Interaction i in obj.GetComponents<Interaction> ()) 
+		if (highlightedObject == null) {
+			return;
+		}
+		
+		foreach (Interaction i in this.highlightedObject.GetComponents<Interaction> ()) 
 		{
 			if (i is AnnotationInteraction || i is SlideshowInteraction)
 			{
@@ -100,18 +105,22 @@ public class FirstPersonInteractor : MonoBehaviour
 
 			if (i.enabled)
 			{ 
-				target.Interact (this.gameObject);		
+				i.Interact (this.gameObject);		
 			} 
 		}
 	}
 
 	private void AttemptReadAnnotation ()
 	{
-		foreach (Interaction i in obj.GetComponents<Interaction> ()) 
+		if (highlightedObject == null) {
+			return;
+		}
+
+		foreach (Interaction i in this.highlightedObject.GetComponents<Interaction> ()) 
 		{
 			if (i.enabled && (i is AnnotationInteraction || i is SlideshowInteraction))
 			{
-				target.Interact (this.gameObject);
+				i.Interact (this.gameObject);
 			}
 		}
 	}
@@ -152,8 +161,8 @@ public class FirstPersonInteractor : MonoBehaviour
 
 	public void SetCanMove(bool canMove)
 	{
-		var playerCompTypeA = player.GetComponent<FirstPersonController> ();
-		var playerCompTypeB = player.GetComponent<RigidbodyFirstPersonController> ();
+		var playerCompTypeA = this.gameObject.GetComponent<FirstPersonController> ();
+		var playerCompTypeB = this.gameObject.GetComponent<RigidbodyFirstPersonController> ();
 
 		if (playerCompTypeA != null)
 		{

--- a/Project/Assets/Prairie/Framework/Script/Interaction/FirstPersonInteractor.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/FirstPersonInteractor.cs
@@ -3,64 +3,120 @@ using System.Collections.Generic;
 
 public class FirstPersonInteractor : MonoBehaviour
 {
+	// Raycast-related
 	public float interactionRange = 3;
-
 	private Camera viewpoint;
 
-	private List<Interaction> avaliableInteractions;
-	private bool interactionAvaliable
-	{
-		get { return avaliableInteractions.Count > 0; }
-	}
+	// Selection-related
+	private GameObject highlightedObject;
+	public List<AnnotationInteraction> areaAnnotationsInRange = new List<AnnotationInteraction>();
 
+	// Control-related
+	[HideInInspector]
+	private bool drawsGUI = true;
+
+	/// --- Game Loop ---
 
 	void Start ()
 	{
 		viewpoint = Camera.main;
 	}
-		
+
 	void Update ()
 	{
-		this.avaliableInteractions = GetAvaliableInteractions ();
+		// update our highlighted object
+		this.highlightedObject = this.GetHighlightedObject();
 
-		if (Input.GetKeyDown (KeyCode.F))
+		// process input
+		if (Input.GetMouseButtonDown (0))
 		{
-			this.AttemptInteract();
+			// left click
+			this.AttemptInteract ();
+		}
+		if (Input.GetMouseButtonDown (1))
+		{
+			// right click
+			this.AttemptReadAnnotation ();
 		}
 	}
+
+	/// --- GUI ---
 
 	void OnGUI()
 	{
-		if (this.interactionAvaliable)
+		if (!this.drawsGUI)
 		{
-			// Draw a GUI with the interaction
-			Rect frame = new Rect (Screen.width / 2, Screen.height / 2, Screen.width / 4, Screen.height / 4);
-			string firstInteractionPrompt = avaliableInteractions [0].prompt;
-            GUI.BeginGroup(frame);
-			GUILayout.Box ("Press F to " + firstInteractionPrompt);
-            GUI.EndGroup();
+			// hide all GUI in certain contexts (such as while slideshow is playing, etc.)
+			return;
 		}
-		else 
+
+
+		if (this.highlightedObject != null)
 		{
-			// hacky way to draw a crosshair 
+			// draw prompt on highlighted object
+			prompt = this.highlightedObject.GetComponent<Prompt> ();
+			if (prompt != null)
+			{
+				prompt.DrawPrompt();
+			}
+
+			// draw potential stub on highlighted annotation object
+			annotation = this.highlightedObject.GetComponent<AnnotationInteraction> ();
+			if (annotation != null)
+			{
+				annotation.DrawSummary();
+			}
+		}
+		else
+		{
+			// draw a crosshair when we have no highlighted object
 			Rect frame = new Rect (Screen.width / 2, Screen.height / 2, 10, 10);
 			GUI.Box (frame, "");
 		}
-
+		
+		// draw toolbar with our set of accessable area annotations
+		this.drawToolbar(this.areaAnnotationsInRange);
 	}
+
+	private void drawToolbar(List<AnnotationInteraction> annotations)
+	{
+		// TODO: Draw a preview (and input button) for each value in `annotations`
+
+		// do not use `this.areaAnnotationsInRange`
+		// This function may move one day, so it'd be better to keep it pure
+	}
+
+	/// --- Handling Interaction ---
 
 	private void AttemptInteract ()
 	{
-		if (interactionAvaliable)
+		foreach (Interaction i in obj.GetComponents<Interaction> ()) 
 		{
-			foreach (Interaction target in avaliableInteractions)
+			if (i is AnnotationInteraction || i is SlideshowInteraction)
+			{
+				// special cases, handled by `AttemptReadAnnotation`
+				continue;
+			}
+
+			if (i.enabled)
+			{ 
+				target.Interact (this.gameObject);		
+			} 
+		}
+	}
+
+	private void AttemptReadAnnotation ()
+	{
+		foreach (Interaction i in obj.GetComponents<Interaction> ()) 
+		{
+			if (i.enabled && (i is AnnotationInteraction || i is SlideshowInteraction))
 			{
 				target.Interact (this.gameObject);
 			}
 		}
 	}
 
-	private List<Interaction> GetAvaliableInteractions ()
+	private GameObject GetHighlightedObject()
 	{
 		// perform a raycast from the main camera to an object in front of it
 		// the object must have a collider to be hit, and an `Interaction` to be added
@@ -76,23 +132,36 @@ public class FirstPersonInteractor : MonoBehaviour
 			if (hit.collider.isTrigger)
 			{
 				// ignore non-physical colliders, such as trigger areas
-				return new List<Interaction> ();
+				return null;
 			}
 
-			GameObject obj = hit.transform.gameObject;
-			List<Interaction> enabledInteractions = new List<Interaction> ();
-			foreach (Interaction i in obj.GetComponents<Interaction> ())
-			{
-				if (i.enabled)
-				{
-					enabledInteractions.Add (i);
-				}
-			}
-			return enabledInteractions;
+			return hit.transform.gameObject;
 		}
 		else
 		{
-			return new List<Interaction> ();	// no interactions, empty list
+			return null;
+		}
+	}
+
+	// --- Changing Player Abilities ---
+
+	public void SetDrawsGUI(bool shouldDraw)
+	{
+		this.drawsGUI = shouldDraw;
+	}
+
+	public void SetCanMove(bool canMove)
+	{
+		var playerCompTypeA = player.GetComponent<FirstPersonController> ();
+		var playerCompTypeB = player.GetComponent<RigidbodyFirstPersonController> ();
+
+		if (playerCompTypeA != null)
+		{
+			playerCompTypeA.enabled = canMove;
+		}
+		if (playerCompTypeB != null)
+		{
+			playerCompTypeB.enabled = canMove;
 		}
 	}
 

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Interaction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Interaction.cs
@@ -1,9 +1,9 @@
 ﻿using UnityEngine;
 using System.Collections;
 
+[RequireComponent(typeof(Prompt))]
 public abstract class Interaction : MonoBehaviour
 {
-	public string prompt;
 	public bool repeatable = true;
 
 	[HideInInspector]

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Prompt.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Prompt.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+using System.Collections;
+
+public class Prompt : MonoBehaviour 
+{
+
+	public string promptText;
+	
+	public void drawPrompt()
+	{
+		// Draw a GUI with the interaction 
+		Rect frame = new Rect (Screen.width / 2, Screen.height / 2, Screen.width / 4, Screen.height / 4); 
+
+		GUI.BeginGroup(frame); 
+			GUILayout.Box ("Click to " + promptText); 
+		GUI.EndGroup(); 
+	}
+
+}
+

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Prompt.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Prompt.cs
@@ -6,7 +6,7 @@ public class Prompt : MonoBehaviour
 
 	public string promptText;
 	
-	public void drawPrompt()
+	public void DrawPrompt()
 	{
 		// Draw a GUI with the interaction 
 		Rect frame = new Rect (Screen.width / 2, Screen.height / 2, Screen.width / 4, Screen.height / 4); 

--- a/Project/Assets/Prairie/Framework/Script/Interaction/SlideshowInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/SlideshowInteraction.cs
@@ -24,7 +24,11 @@ public class SlideshowInteraction : Interaction
 		CurrentSlide = 0;
 
 		// Disable player movement/interactor upon interaction
-		this.SetPlayerIsFrozen (true);
+		FirstPersonInteractor player = this.GetPlayer ();
+		if (player != null) {
+			player.SetCanMove (false);
+			player.SetDrawsGUI (false);
+		}
 	}
 
 	/// <summary>
@@ -102,7 +106,11 @@ public class SlideshowInteraction : Interaction
 		{
 			// Upon ESC, exit from GUI and reenable player control
 			Active = false;
-			this.SetPlayerIsFrozen (false);
+			FirstPersonInteractor player = this.GetPlayer ();
+			if (player != null) {
+				player.SetCanMove (true);
+				player.SetDrawsGUI (true);
+			}
 		}
 	}
 }

--- a/Project/Assets/Prairie/Framework/Script/Interaction/TumbleInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/TumbleInteraction.cs
@@ -45,7 +45,11 @@ public class TumbleInteraction : Interaction
 			}
 			else if (Input.GetKey(KeyCode.Q) || Input.GetKey(KeyCode.Escape))
 			{
-				this.SetPlayerIsFrozen(false);
+				FirstPersonInteractor player = this.GetPlayer ();
+				if (player != null) {
+					player.SetCanMove (true);
+					player.SetDrawsGUI (true);
+				}
 				pickedUp = false;
 			}
 		}
@@ -53,6 +57,10 @@ public class TumbleInteraction : Interaction
 
 	protected override void PerformAction() {
 		pickedUp = true;
-		this.SetPlayerIsFrozen(true);
+		FirstPersonInteractor player = this.GetPlayer ();
+		if (player != null) {
+			player.SetCanMove (false);
+			player.SetDrawsGUI (false);
+		}
 	}
 }

--- a/Project/Assets/Prairie/Framework/Script/Support/UtilityExtensions.cs
+++ b/Project/Assets/Prairie/Framework/Script/Support/UtilityExtensions.cs
@@ -3,7 +3,7 @@ using UnityStandardAssets.Characters.FirstPerson;
 
 public static class InteractionExtensions {
 
-	public static FirstPersonInteractor GetPlayer(this Interaction i, bool canMove)
+	public static FirstPersonInteractor GetPlayer(this Interaction i)
 	{
 		if (i.rootInteractor != null)
 		{

--- a/Project/Assets/Prairie/Framework/Script/Support/UtilityExtensions.cs
+++ b/Project/Assets/Prairie/Framework/Script/Support/UtilityExtensions.cs
@@ -1,49 +1,16 @@
 using UnityEngine;
 using UnityStandardAssets.Characters.FirstPerson;
 
-public static class PlayerExtensions
-{
-
-	/// <summary>
-	/// Sets the player state to be locked if true, free to move if untrue.
-	/// </summary>
-	/// <param name="isFrozen">If <c>true</c>, the player can not move.</param>
-	public static void SetIsFrozen(this FirstPersonInteractor player, bool isFrozen)
-	{
-		var playerCompTypeA = player.GetComponent<FirstPersonController> ();
-
-		var playerCompTypeB = player.GetComponent<RigidbodyFirstPersonController> ();
-
-		if (playerCompTypeA != null)
-		{
-			playerCompTypeA.enabled = !isFrozen;
-		}
-		if (playerCompTypeB != null)
-		{
-			playerCompTypeB.enabled = !isFrozen;
-		}
-
-		player.enabled = !isFrozen;
-	}
-
-}
-
 public static class InteractionExtensions {
 
-	/// <summary>
-	/// Sets the player who triggered this Interaction's state to be locked if true, free to move if untrue.
-	/// </summary>
-	/// <param name="isFrozen">If <c>true</c>, the player can not move.</param>
-	public static void SetPlayerIsFrozen(this Interaction i, bool isFrozen)
+	public static void GetPlayer(this Interaction i, bool canMove)
 	{
 		if (i.rootInteractor != null)
 		{
 			FirstPersonInteractor player = i.rootInteractor.GetComponent<FirstPersonInteractor> ();
-			if (player != null)
-			{
-				player.SetIsFrozen(isFrozen);
-			}
+			return player
 		}
+		return null
 	}
 
 }

--- a/Project/Assets/Prairie/Framework/Script/Support/UtilityExtensions.cs
+++ b/Project/Assets/Prairie/Framework/Script/Support/UtilityExtensions.cs
@@ -3,7 +3,7 @@ using UnityStandardAssets.Characters.FirstPerson;
 
 public static class InteractionExtensions {
 
-	public static void GetPlayer(this Interaction i, bool canMove)
+	public static FirstPersonInteractor GetPlayer(this Interaction i, bool canMove)
 	{
 		if (i.rootInteractor != null)
 		{

--- a/Project/Assets/Prairie/Framework/Script/Support/UtilityExtensions.cs
+++ b/Project/Assets/Prairie/Framework/Script/Support/UtilityExtensions.cs
@@ -8,9 +8,9 @@ public static class InteractionExtensions {
 		if (i.rootInteractor != null)
 		{
 			FirstPersonInteractor player = i.rootInteractor.GetComponent<FirstPersonInteractor> ();
-			return player
+			return player;
 		}
-		return null
+		return null;
 	}
 
 }


### PR DESCRIPTION
This PR includes a bunch of sweeping changes to make way for and help aid the transition into Annotations 2.0 and resolves conflict with prompts (and some basic multiple interaction business).

A swath of this PR includes stubs to be filled out after this is pulled into `master`.

# Gameplay/ Editor Changes
### Player Actions
Left click to interact with all interactions that aren't annotation-based (`Swivel`, `Toggle`, etc.). Right click for annotation-based interactions (`Annotation`, `Slideshow`).

### Prompt
`Prompt` is automatically added to the top level of components when adding an interaction if it doesn't already exist. It's pretty slick. Unfortunately, existing scenes don't get prompts added to them, so our prototype scenes are officially obsolete (again).

# Stubs to Fill In
### Player Area Annotations Property
`.areaAnnotationsInRange` __must be coordinated and set by appropriate area annotations__ as the player enters and exits their bounding boxes.

### Player Toolbar
The player will automatically draw a toolbar with `.areaAnnotationsInRange` as its contents using `drawToolbar(annotations)`. This function must be implemented.

We also need a good way to activate items in that toolbar...

### Annotation drawing Summary
Annotations must be given a summary field and draw it to screen (if it exists) inside of `Annotation.DrawSummary()`.

# API Changes
### Prompt
Interactions no longer have a `prompt` string property and instead just rely on a `Prompt` component to perform the equivalent logic.

### Manipulating the Player in Interactions
Freezing the player can no longer be done via the extension method. Interactions must get a reference to the player through `GetPlayer()` then use `player.SetCanMove(bool)`.

This is inline with the similar action of stopping GUI drawing for the player `player.SetDrawsGUI(bool)`

- removed `void SetPlayerIsFrozen(bool)` from Player and Interaction
- added `void SetCanMove(bool)` and `void SetDrawsGUI(bool)` on Player
- added `FirstPersonInteractor GetPlayer()` to Interaction