### PR TITLE
Minimize TwineNode text when user presses Tab

### DIFF
--- a/Project/Assets/Prairie/Framework/Script/Twine/TwineNode.cs
+++ b/Project/Assets/Prairie/Framework/Script/Twine/TwineNode.cs
@@ -16,19 +16,35 @@ public class TwineNode : MonoBehaviour {
 	public string[] childrenNames;
 	public List<GameObject> parents = new List<GameObject> ();
 
+	private bool isMinimized = false;
+
+	void Update ()
+	{
+		if (Input.GetKeyDown (KeyCode.Tab))
+		{
+			this.ToggleMinimize ();
+		}
+	}
+
 	public void OnGUI()
 	{
-		if (this.enabled) 
-		{
+		if (this.enabled && !this.isMinimized) {
+
 			float frameWidth = Screen.width / 3;
 			Rect frame = new Rect (10, 10, frameWidth, Screen.height);
 
-			GUI.BeginGroup(frame);
-			GUIStyle style = new GUIStyle(GUI.skin.box);
+			GUI.BeginGroup (frame);
+			GUIStyle style = new GUIStyle (GUI.skin.box);
 			style.wordWrap = true;
 			style.fixedWidth = frameWidth;
 			GUILayout.Box (this.content, style);
 			GUI.EndGroup ();
+
+		} else if (this.enabled && this.isMinimized) 
+		{
+		
+			// Draw minimized GUI instead
+
 
 		}
 	}
@@ -58,6 +74,7 @@ public class TwineNode : MonoBehaviour {
 		if (!this.enabled && this.HasActiveParentNode()) 
 		{
 			this.enabled = true;
+			this.isMinimized = false;
 			this.DeactivateAllParents ();
 			this.StartInteractions (interactor);
 		}
@@ -94,6 +111,11 @@ public class TwineNode : MonoBehaviour {
 		{
 			parent.GetComponent<TwineNode> ().Deactivate ();
 		}
+	}
+
+	private void ToggleMinimize()
+	{
+		this.isMinimized = !this.isMinimized;
 	}
 
 	// GIZMOS

--- a/Project/Assets/Prairie/Framework/Script/Twine/TwineNode.cs
+++ b/Project/Assets/Prairie/Framework/Script/Twine/TwineNode.cs
@@ -44,7 +44,9 @@ public class TwineNode : MonoBehaviour {
 		{
 		
 			// Draw minimized GUI instead
+			Rect frame = new Rect (10, 10, 10, 10);
 
+			GUI.Box (frame, "");
 
 		}
 	}


### PR DESCRIPTION
Now there are two separate GUI states to draw for a TwineNode: either the text is minimized or it's not.

For now, minimized text draws an empty GUI, a la crosshair. But we could make it hide entirely or show something else (like "Press Tab to see Twine passage" or something).

Whenever a new node is activated (e.g. if you enter a new room and trigger a Twine node), the GUI is automatically set to active.

Here's a GIF of it in action (in the top left corner):

![](https://media.giphy.com/media/26xBsLlYoK52AiX1C/giphy.gif)

See #73 