### PR TITLE
Prompt defaults when automatically added in editor

### DIFF
--- a/Project/Assets/Prairie/Framework/Script/Interaction/AudioInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/AudioInteraction.cs
@@ -32,8 +32,11 @@ public class AudioInteraction : Interaction
             audioSource.Play();
             playing = true;
         }
-        
-        
-        
+    }
+
+    override public string defaultPrompt {
+        get {
+            return "Play Audio";
+        }
     }
 }

--- a/Project/Assets/Prairie/Framework/Script/Interaction/ComponentToggleInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/ComponentToggleInteraction.cs
@@ -22,4 +22,10 @@ public class ComponentToggleInteraction : Interaction
 			target[i].enabled = !target[i].enabled;
 		}
 	}
+
+	override public string defaultPrompt {
+		get {
+			return "Toggle Something";
+		}
+	}
 }

--- a/Project/Assets/Prairie/Framework/Script/Interaction/DebugInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/DebugInteraction.cs
@@ -8,4 +8,10 @@ public class DebugInteraction : Interaction
 		Debug.Log ("Interacted with " + this.gameObject.name);
 	}
 
+	override public string defaultPrompt {
+		get {
+			return "Debug to Console";
+		}
+	}
+
 }

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Interaction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Interaction.cs
@@ -26,4 +26,27 @@ public abstract class Interaction : MonoBehaviour
 
 	protected abstract void PerformAction ();
 
+	/// <summary>
+	/// Return a default prompt suitable for this interaction type, for pre-populating a Prompt object.
+	/// Note that this value will only affect the editing user experience.
+	/// Changing this during gameplay will have NO EFFECT on the prompt.
+	/// </summary>
+	/// <value>A sensible default, or null if no such sensible default is appropriate.</value>
+	public virtual string defaultPrompt {
+		get { return null; }
+	}
+
+	// Typically, when a component is added to the inspector for the first time,
+	// it automatically appends a 'Prompt' component as well.
+	//
+	// Having this call here ensures that, no matter the order of instantiation,
+	// any newly added Prompt component recieves a default value.
+	public void Reset()
+	{
+		Prompt prompt = this.gameObject.GetComponent<Prompt> ();
+		if (prompt.promptText == null || prompt.promptText == "") {
+			prompt.SetDefaultPrompt ();
+		}
+	}
+
 }

--- a/Project/Assets/Prairie/Framework/Script/Interaction/NextTwineNodeInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/NextTwineNodeInteraction.cs
@@ -22,5 +22,11 @@ public class NextTwineNodeInteraction : Interaction
 			twineNode.Activate (this.rootInteractor);
 		}
 	}
+
+	override public string defaultPrompt {
+		get {
+			return "Progress the Story";
+		}
+	}
 }
 

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Prompt.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Prompt.cs
@@ -13,5 +13,35 @@ public class Prompt : MonoBehaviour
 		GUILayout.Box (promptText); 
 		GUI.EndGroup();
 	}
+
+	// `Reset()` is called when this component is being added to a
+	// GameObject in the Inpsector for the first time, or if the user
+	// explicitly clicks the "reset" button on the component.
+	//
+	// Here, we use it to set a sensible default for the component,
+	// based on the presense of interaction components.
+	public void Reset()
+	{
+		this.SetDefaultPrompt ();
+	}
+
+	public void SetDefaultPrompt()
+	{
+		string prompt = "";
+		GameObject source = this.gameObject;
+		foreach (Interaction i in source.GetComponents<Interaction> ())
+		{
+			if (i.defaultPrompt != null)
+			{
+				if (prompt != "") {
+					prompt += ", ";		// seperate multiple actions
+				}
+				prompt += i.defaultPrompt;
+			}
+		}
+
+		this.promptText = prompt;
+	}
+
 }
 

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Slideshow.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Slideshow.cs
@@ -113,4 +113,10 @@ public class Slideshow : Interaction
 			}
 		}
 	}
+
+	override public string defaultPrompt {
+		get {
+			return "Play Slideshow";
+		}
+	}
 }

--- a/Project/Assets/Prairie/Framework/Script/Interaction/SwivelInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/SwivelInteraction.cs
@@ -62,4 +62,10 @@ public class SwivelInteraction : Interaction
 			targetAngle += rotationAmount;
 		}
 	}
+
+	override public string defaultPrompt {
+		get {
+			return "Open Door";
+		}
+	}
 }

--- a/Project/Assets/Prairie/Framework/Script/Interaction/TriggerInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/TriggerInteraction.cs
@@ -13,4 +13,11 @@ public class TriggerInteraction : Interaction
             target.InteractAll(this.rootInteractor);
         }
     }
+
+	override public string defaultPrompt {
+		get {
+			return "Trigger Something";
+		}
+	}
+
 }

--- a/Project/Assets/Prairie/Framework/Script/Interaction/TumbleInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/TumbleInteraction.cs
@@ -61,4 +61,10 @@ public class TumbleInteraction : Interaction
 			}
 		}
 	}
+
+	override public string defaultPrompt {
+		get {
+			return "Pick up Object";
+		}
+	}
 }


### PR DESCRIPTION
Fix for the concern raised in #82.

`Interactions` can now provide a default prompt value, which will be automatically inserted into the new prompt (when it is first added).

I provided such defaults for our existing `Interactions` in common use.