### PR TITLE
made fields read only

### DIFF
--- a/Project/Assets/Editor/CustomInspectors/SwivelEditor.cs.meta
+++ b/Project/Assets/Editor/CustomInspectors/SwivelEditor.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: c7468062b66c742d0b71345e3ace819f
-timeCreated: 1477364756
+guid: 415efa4ba2b5242fcb52e7650b87c1c5
+timeCreated: 1486263754
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Project/Assets/Editor/CustomInspectors/TumbleEditor.cs.meta
+++ b/Project/Assets/Editor/CustomInspectors/TumbleEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 311145eed73094bab8b21b4837ca7fe6
+timeCreated: 1486263754
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project/Assets/Editor/CustomInspectors/TwineNodeEditor.cs
+++ b/Project/Assets/Editor/CustomInspectors/TwineNodeEditor.cs
@@ -16,12 +16,12 @@ public class TwineNodeEditor : Editor {
 
 		node.isDecisionNode = EditorGUILayout.Toggle ("Decision node?", node.isDecisionNode);
 		node.objectsToTrigger = PrairieGUI.drawObjectList ("Objects To Trigger", node.objectsToTrigger);
-		node.name = EditorGUILayout.TextField ("Name", node.name);
-		node.tags = PrairieGUI.drawPrimitiveList ("Tags", node.tags);
+		node.name = PrairieGUI.TextFieldReadOnly ("Name", node.name);
+		node.tags = PrairieGUI.drawPrimitiveListReadOnly ("Tags", node.tags);
 		node.content = EditorGUILayout.TextField ("Content", node.content);
-		node.children = PrairieGUI.drawObjectList ("Children", node.children);
+		node.children = PrairieGUI.drawObjectListReadOnly ("Children", node.children);
 		GameObject[] parentArray = node.parents.ToArray ();
-		parentArray = PrairieGUI.drawObjectList ("Parents", parentArray);
+		parentArray = PrairieGUI.drawObjectListReadOnly ("Parents", parentArray);
 		node.parents = new List<GameObject> (parentArray);
 
 		// Save changes to the TwineNode if the user edits something in the GUI:

--- a/Project/Assets/Editor/CustomInspectors/TwineNodeEditor.cs
+++ b/Project/Assets/Editor/CustomInspectors/TwineNodeEditor.cs
@@ -18,7 +18,11 @@ public class TwineNodeEditor : Editor {
 		node.objectsToTrigger = PrairieGUI.drawObjectList ("Objects To Trigger", node.objectsToTrigger);
 		EditorGUILayout.LabelField ("Name", node.name);
 //		node.tags = PrairieGUI.drawPrimitiveListReadOnly ("Tags", node.tags);
-		node.content = EditorGUILayout.TextField ("Content", node.content);
+//		node.content = EditorGUILayout.TextField ("Content", node.content);
+		EditorGUILayout.LabelField ("Content");
+		EditorGUI.indentLevel += 1;
+		node.content = EditorGUILayout.TextArea (node.content);
+		EditorGUI.indentLevel -= 1;
 		node.children = PrairieGUI.drawObjectListReadOnly ("Children", node.children);
 		GameObject[] parentArray = node.parents.ToArray ();
 		parentArray = PrairieGUI.drawObjectListReadOnly ("Parents", parentArray);

--- a/Project/Assets/Editor/CustomInspectors/TwineNodeEditor.cs
+++ b/Project/Assets/Editor/CustomInspectors/TwineNodeEditor.cs
@@ -17,8 +17,6 @@ public class TwineNodeEditor : Editor {
 		node.isDecisionNode = EditorGUILayout.Toggle ("Decision node?", node.isDecisionNode);
 		node.objectsToTrigger = PrairieGUI.drawObjectList ("Objects To Trigger", node.objectsToTrigger);
 		EditorGUILayout.LabelField ("Name", node.name);
-//		node.tags = PrairieGUI.drawPrimitiveListReadOnly ("Tags", node.tags);
-//		node.content = EditorGUILayout.TextField ("Content", node.content);
 		EditorGUILayout.LabelField ("Content");
 		EditorGUI.indentLevel += 1;
 		node.content = EditorGUILayout.TextArea (node.content);

--- a/Project/Assets/Editor/CustomInspectors/TwineNodeEditor.cs
+++ b/Project/Assets/Editor/CustomInspectors/TwineNodeEditor.cs
@@ -16,8 +16,8 @@ public class TwineNodeEditor : Editor {
 
 		node.isDecisionNode = EditorGUILayout.Toggle ("Decision node?", node.isDecisionNode);
 		node.objectsToTrigger = PrairieGUI.drawObjectList ("Objects To Trigger", node.objectsToTrigger);
-		node.name = PrairieGUI.TextFieldReadOnly ("Name", node.name);
-		node.tags = PrairieGUI.drawPrimitiveListReadOnly ("Tags", node.tags);
+		EditorGUILayout.LabelField ("Name", node.name);
+//		node.tags = PrairieGUI.drawPrimitiveListReadOnly ("Tags", node.tags);
 		node.content = EditorGUILayout.TextField ("Content", node.content);
 		node.children = PrairieGUI.drawObjectListReadOnly ("Children", node.children);
 		GameObject[] parentArray = node.parents.ToArray ();

--- a/Project/Assets/Editor/Utilities/PrairieGUI.cs
+++ b/Project/Assets/Editor/Utilities/PrairieGUI.cs
@@ -22,6 +22,30 @@ public class PrairieGUI {
         GUILayout.Label(text, warningLabel);
 	}
 
+	public static string TextFieldReadOnly (string title, string fieldContents)
+	{
+		GUI.enabled = false;
+		string retVal = EditorGUILayout.TextField (title, fieldContents);
+		GUI.enabled = true;
+		return retVal;
+	}
+
+	public static T[] drawObjectListReadOnly <T> (string title, T[] array) where T : UnityEngine.Object
+	{
+		GUI.enabled = false;
+		T[] retVal = drawObjectList (title, array);
+		GUI.enabled = true;
+		return retVal;
+	}
+
+	public static T[] drawPrimitiveListReadOnly <T> (string title, T[] array) where T : IConvertible
+	{
+		GUI.enabled = false;
+		T[] retval = drawPrimitiveList (title, array);
+		GUI.enabled = true;
+		return retval;
+	}
+
 	public static T[] drawObjectList <T> (string title, T[] array) where T : UnityEngine.Object
 	{
 		EditorGUILayout.PrefixLabel (title);

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Swivel.cs.meta
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Swivel.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: a2114adace3cd46d098696c4fac0f18a
-timeCreated: 1478482174
+guid: 3fe564745890b4bdd9b967a046965c96
+timeCreated: 1486263754
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Tumble.cs.meta
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Tumble.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 815bf9ca0660541c5a6879db27c4f8ba
+timeCreated: 1486263754
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project/Assets/Prairie/Framework/Script/Twine/TwineNode.cs
+++ b/Project/Assets/Prairie/Framework/Script/Twine/TwineNode.cs
@@ -11,6 +11,7 @@ public class TwineNode : MonoBehaviour {
 	[HideInInspector]
 	public string pid;
 	public new string name;
+	[HideInInspector]
 	public string[] tags;
 	public string content;
 	public GameObject[] children;


### PR DESCRIPTION
For issue #95 

I took the fields that we already have and made them read only.  They look exactly like they did before, but now read only (and thus you cannot add or remove fields either).  When you click on an uneditable object, then it flashes the object that you clicked on in the hierarchy (or the assets if you have not dragged it into the hierarchy).

For the lists particularly, it is possible to make it so that the plus and minus buttons are there.  However, it would mean more or less rewriting the original display functions with just a few minor tweaks, which I am willing to do.  It just means chunks of repeated code, which in general we want to avoid, but might make things look nicer.  So we might want to figure out if we want the plus and minus buttons or not.

I did not make read only fields of everything (because I didn't think we needed them), but I can do so if we want to.

I also found this other way of making fields read only, but I think us making our own GUIs conflicted with it (and I couldn't get it to work properly anyways).  We can attempt to use it (and tweak it) if you think that is a better idea, so that's why the link is below.
http://answers.unity3d.com/questions/489942/how-to-make-a-readonly-property-in-inspector.html