### PR TITLE
Create component menu organization

### DIFF
--- a/Project/Assets/Prairie/Framework/Script/Annotation/Annotation.cs
+++ b/Project/Assets/Prairie/Framework/Script/Annotation/Annotation.cs
@@ -20,7 +20,7 @@ public class AnnotationContent
 public enum AnnotationTypes : int {SUMMARY = 0, AREA = 1 };
 public enum ImportTypes : int {NONE = 0, IMPORT = 1, INSPECTOR = 2 };
 
-
+[AddComponentMenu("Prairie/Annotation/Annotation")]
 public class Annotation : Interaction
 {
     public AnnotationContent content;

--- a/Project/Assets/Prairie/Framework/Script/Interaction/AssociatedTwineNodes.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/AssociatedTwineNodes.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 
+[AddComponentMenu("Prairie/Twine/Associated Twine Nodes")]
 public class AssociatedTwineNodes : PromptInteraction 
 {
 	public List<GameObject> associatedTwineNodeObjects = new List<GameObject>();

--- a/Project/Assets/Prairie/Framework/Script/Interaction/AudioInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/AudioInteraction.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using System.Collections;
 
+[AddComponentMenu("Prairie/Interactions/Play Audio")]
 public class AudioInteraction : PromptInteraction
 {
     public AudioClip audioClip;

--- a/Project/Assets/Prairie/Framework/Script/Interaction/ComponentToggleInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/ComponentToggleInteraction.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using System.Collections;
 
+[AddComponentMenu("Prairie/Interactions/Toggle Component")]
 public class ComponentToggleInteraction : PromptInteraction 
 {
 	public Behaviour[] target;

--- a/Project/Assets/Prairie/Framework/Script/Interaction/DebugInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/DebugInteraction.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using System.Collections;
 
+[AddComponentMenu("Prairie/Interactions/Debug")]
 public class DebugInteraction : PromptInteraction 
 {
 	protected override void PerformAction () 

--- a/Project/Assets/Prairie/Framework/Script/Interaction/FirstPersonInteractor.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/FirstPersonInteractor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityStandardAssets.Characters.FirstPerson;
 
+[AddComponentMenu("Prairie/Player/First Person Interactor")]
 public class FirstPersonInteractor : MonoBehaviour
 {
 	// Raycast-related

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Prompt.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Prompt.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using System.Collections;
 
+[AddComponentMenu("Prairie/Interactions/Prompt")]
 public class Prompt : MonoBehaviour 
 {
 	public string promptText;

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Prompt.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Prompt.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using System.Collections;
 
-[AddComponentMenu("Prairie/Interactions/Prompt")]
+[AddComponentMenu("Prairie/Utility/Prompt")]
 public class Prompt : MonoBehaviour 
 {
 	public string promptText;

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Slideshow.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Slideshow.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using System.Collections;
 
+[AddComponentMenu("Prairie/Interactions/Slideshow")]
 public class Slideshow : PromptInteraction
 {
 	private bool Active = false;

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Slideshow.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Slideshow.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using System.Collections;
 
-[AddComponentMenu("Prairie/Interactions/Slideshow")]
+[AddComponentMenu("Prairie/Annotation/Slideshow")]
 public class Slideshow : PromptInteraction
 {
 	private bool Active = false;

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Swivel.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Swivel.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using System.Collections;
 
+[AddComponentMenu("Prairie/Interactions/Door Swivel")]
 public class Swivel : PromptInteraction
 {
 	public bool openFromLeft = false;

--- a/Project/Assets/Prairie/Framework/Script/Interaction/TriggerArea.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/TriggerArea.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using System.Collections;
 
+[AddComponentMenu("Prairie/Interactions/Trigger Area")]
 [RequireComponent(typeof(Collider))]
 public class TriggerArea : MonoBehaviour
 {

--- a/Project/Assets/Prairie/Framework/Script/Interaction/TriggerInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/TriggerInteraction.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using System.Collections;
 
+[AddComponentMenu("Prairie/Interactions/Trigger Interaction")]
 public class TriggerInteraction : PromptInteraction
 {
 

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Tumble.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Tumble.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using System.Collections;
 
+[AddComponentMenu("Prairie/Interactions/Tumble")]
 public class Tumble : PromptInteraction
 {
 	/// <summary>

--- a/Project/Assets/Prairie/Framework/Script/Twine/TwineNode.cs
+++ b/Project/Assets/Prairie/Framework/Script/Twine/TwineNode.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System;
 using System.Linq;
 
-
+[AddComponentMenu("Prairie/Utility/Twine Node")]
 public class TwineNode : MonoBehaviour {
 
 	public GameObject[] objectsToTrigger;


### PR DESCRIPTION
This is a really small pull request. It just adds some attributes to components, allowing them to be organized under 'prairie' instead of scripts in the component menu. It is for better ease of use/ user accessibility.

This is to fulfill Issue #127 

![componentmenu](https://cloud.githubusercontent.com/assets/13103592/22759741/2cd5d7f4-ee19-11e6-875a-18047239ef9f.gif)


