### PR TITLE
Remove Tumble interaction Gizmo

### DIFF
--- a/Project/Assets/Prairie/Framework/Script/Interaction/Tumble.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Tumble.cs
@@ -9,19 +9,9 @@ public class Tumble : PromptInteraction
 	/// </summary>
 	private bool pickedUp = false;
 
-	public static Mesh tumbleMesh;
-
 	// When the user interacts with object, they invoke the ability to 
 	// tumble the object with the I, J, K and L keys. Interacting
 	// with the object again revokes this ability.
-
-	void OnDrawGizmos() 
-	{
-		// Draw a yellow static mesh of the object's starting orientation
-		Gizmos.color = Color.yellow;
-		tumbleMesh = GetComponent<MeshFilter> ().sharedMesh;
-		Gizmos.DrawWireMesh (tumbleMesh, transform.position);
-	}
 
 	protected void Update()
 	{


### PR DESCRIPTION
The Gizmo we currently have implemented in `Tumble.cs` is pretty unwieldy, and we have no simple methodology to make it any more useful.

Bottom line, it's useless and gross and needs to die.

This PR stomps it.

Resolves issue #132 