### PR TITLE
The return of repeatables, and minor things

### DIFF
--- a/Project/Assets/Editor/CustomInspectors/AudioInteractionEditor.cs
+++ b/Project/Assets/Editor/CustomInspectors/AudioInteractionEditor.cs
@@ -10,7 +10,8 @@ public class AudioInteractionEditor : Editor {
 
 	public override void OnInspectorGUI() 
 	{
-		audio = (AudioInteraction)target;
+		this.audio = (AudioInteraction)target;
+
 		audio.repeatable = EditorGUILayout.Toggle ("Replayable?", audio.repeatable);
 		audio.audioClip = (AudioClip)EditorGUILayout.ObjectField ("Audio Clip", audio.audioClip, typeof(AudioClip), true);
 
@@ -20,14 +21,14 @@ public class AudioInteractionEditor : Editor {
 			audio.audioSource = (AudioSource)EditorGUILayout.ObjectField ("Audio Source", audio.audioSource, typeof(AudioSource), true);
 		}
 
-		if (audio.audioClip == null) 
-		{
-			DrawWarnings ();
-		}
+		this.DrawWarnings ();
 	}
 
 	public void DrawWarnings()
 	{
-		PrairieGUI.warningLabel ("No audio clip attached to object.  Please add an audio clip to the slot above.");
+		if (audio.audioClip == null) 
+		{
+			PrairieGUI.warningLabel ("No audio clip attached to object.  Please add an audio clip to the slot above.");
+		}
 	}
 }

--- a/Project/Assets/Editor/CustomInspectors/ComponentToggleInteractionEditor.cs
+++ b/Project/Assets/Editor/CustomInspectors/ComponentToggleInteractionEditor.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEditor;
 
 [CustomEditor(typeof(ComponentToggleInteraction))]
@@ -7,23 +6,25 @@ public class ComponentToggleInteractionEditor : Editor {
 
 	ComponentToggleInteraction componentToggle;
 
-	public override void OnInspectorGUI()
+	public override void OnInspectorGUI ()
 	{
-		componentToggle = (ComponentToggleInteraction)target;
-		componentToggle.target = PrairieGUI.drawObjectList ("Behaviours To Toggle", componentToggle.target);
+		this.componentToggle = (ComponentToggleInteraction)target;
 
-		for (int i = 0; i < componentToggle.target.Length; i++) 
-		{
-			if (componentToggle.target [i] == null) 
-			{
-				DrawWarnings ();
-				break;
-			}
-		}
+		componentToggle.repeatable = EditorGUILayout.Toggle ("Repeatable?", componentToggle.repeatable);
+		componentToggle.target = PrairieGUI.drawObjectList<Behaviour> ("Behaviours To Toggle:", componentToggle.target);
+
+		this.DrawWarnings();
 	}
 
 	public void DrawWarnings()
 	{
-		PrairieGUI.warningLabel ("You have one or more empty slots in your list of toggles.  Please fill these slots or remove them.");
+		foreach (Behaviour behaviour in componentToggle.target) 
+		{
+			if (behaviour == null) 
+			{
+				PrairieGUI.warningLabel ("You have one or more empty slots in your list of toggles.  Please fill these slots or remove them.");
+				break;
+			}
+		}
 	}
 }

--- a/Project/Assets/Editor/CustomInspectors/TriggerInteractionEditor.cs
+++ b/Project/Assets/Editor/CustomInspectors/TriggerInteractionEditor.cs
@@ -11,6 +11,7 @@ public class TriggerInteractionEditor : Editor {
 		this.trigger = (TriggerInteraction)target;
 
 		// Principle Configuration:
+		trigger.repeatable = EditorGUILayout.Toggle ("Repeatable?", trigger.repeatable);
 		trigger.triggeredObjects = PrairieGUI.drawObjectList<GameObject> ("Trigger Objects:", trigger.triggeredObjects);
 
 		// Warnings:

--- a/Project/Assets/Prairie/Framework/Script/Interaction/ComponentToggleInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/ComponentToggleInteraction.cs
@@ -4,7 +4,7 @@ using System.Collections;
 [AddComponentMenu("Prairie/Interactions/Toggle Component")]
 public class ComponentToggleInteraction : PromptInteraction 
 {
-	public Behaviour[] target;
+	public Behaviour[] target = new Behaviour[0];
 
 	void OnDrawGizmosSelected()
 	{

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Slideshow.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Slideshow.cs
@@ -6,7 +6,7 @@ public class Slideshow : PromptInteraction
 {
 	private bool Active = false;
 
-	public Texture2D[] Slides;
+	public Texture2D[] Slides = new Texture2D[0];
 	public int CurrentSlide;
 
 	private Rect Shading;


### PR DESCRIPTION
This PR brings back the `Repeatable` toggleable checkbox for the following interactions' GUIs:

* `AudioInteraction`
* `ComponentToggleInteraction`
* `TriggerInteraction`

This will potentially help us out with our issue with deactivated Interactions (#135).  Otherwise, more power to the user!

Resolves issue #139.

This PR also adds fixes to a couple of small bugs in `ComponentToggleInteraction` and `Slideshow`, wherein upon first adding the script to an object, the (+) button in its custom GUI doesn't appear until the inspector is refreshed.