### PR TITLE
Adding cyclic prompts

### DIFF
--- a/Project/Assets/Editor/CustomInspectors/PromptEditor.cs
+++ b/Project/Assets/Editor/CustomInspectors/PromptEditor.cs
@@ -11,13 +11,26 @@ public class PromptEditor : Editor {
 		prompt = (Prompt)target;
 
 		GUIContent label = new GUIContent ("Prompt Text", "Text displayed when a player can interact with this object.");
-		prompt.promptText = EditorGUILayout.TextField (label, prompt.promptText);
+		prompt.firstPrompt = EditorGUILayout.TextField (label, prompt.firstPrompt);
 
-		if (prompt.promptText == null || prompt.promptText == "")
+		if (string.IsNullOrEmpty(prompt.firstPrompt.Trim()))
 		{
-			// I feel like there should be a warning here, but I don't know what to write
-			// PrairieGUI.warningLabel("?")
-		}
+            PrairieGUI.warningLabel("No prompt will be displayed in game.");
+		} else
+        {
+            GUIContent cyclicLabel = new GUIContent("Cyclic Prompt", "Does this prompt have two cycling values? (i.e. open, close)");
+            prompt.isCyclic = EditorGUILayout.Toggle(cyclicLabel, prompt.isCyclic);
+            if (prompt.isCyclic)
+            {
+
+                GUIContent secondLabel = new GUIContent("Second Prompt", "Second prompt to display, will toggle between this and first prompt.");
+                prompt.secondPrompt = EditorGUILayout.TextField(secondLabel, prompt.secondPrompt);
+                if (string.IsNullOrEmpty(prompt.secondPrompt.Trim()))
+                {
+                    PrairieGUI.warningLabel("Second prompt will be ignored.");
+                }
+            }
+        }
 
 		if (GUI.changed) {
 			EditorUtility.SetDirty(prompt);

--- a/Project/Assets/Prairie/Framework/Script/Interaction/FirstPersonInteractor.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/FirstPersonInteractor.cs
@@ -68,7 +68,7 @@ public class FirstPersonInteractor : MonoBehaviour
 		{
 			// draw prompt on highlighted object
 			Prompt prompt = this.highlightedObject.GetComponent<Prompt> ();
-			if (prompt != null && prompt.promptText.Trim() != "")
+			if (prompt != null && prompt.GetPrompt().Trim() != "")
 			{
 				prompt.DrawPrompt();
 			} else {
@@ -175,7 +175,13 @@ public class FirstPersonInteractor : MonoBehaviour
 				i.Interact (this.gameObject);		
 			} 
 		}
-	}
+
+        if (this.highlightedObject.GetComponent<Prompt>() != null)
+        {
+            this.highlightedObject.GetComponent<Prompt>().CyclePrompt();
+        }
+    }
+
 
 	private void AttemptReadAnnotation ()
 	{

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Prompt.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Prompt.cs
@@ -4,16 +4,35 @@ using System.Collections;
 [AddComponentMenu("Prairie/Utility/Prompt")]
 public class Prompt : MonoBehaviour 
 {
-	public string promptText;
+    private static readonly int FIRST_PROMPT = 1;
+    private static readonly int SECOND_PROMPT = 2;
+
+    public bool isCyclic = false;
+
+    public int curPrompt = FIRST_PROMPT;
+    public string firstPrompt = "";
+    public string secondPrompt = "";
 	
+    public string GetPrompt()
+    {
+        if (curPrompt == FIRST_PROMPT)
+        {
+            return this.firstPrompt;
+        }
+        else
+        {
+            return this.secondPrompt;
+        }
+    }
+
 	public void DrawPrompt()
 	{
 		// Draw a GUI with the interaction 
-        if (!string.IsNullOrEmpty(promptText.Trim()))
+        if (!string.IsNullOrEmpty(this.GetPrompt().Trim()))
         {
             Rect frame = new Rect(Screen.width / 2, Screen.height / 2, Screen.width / 4, Screen.height / 4);
             GUI.BeginGroup(frame);
-            GUILayout.Box(promptText);
+            GUILayout.Box(this.GetPrompt());
             GUI.EndGroup();
         }
 	}
@@ -44,8 +63,24 @@ public class Prompt : MonoBehaviour
 			}
 		}
 
-		this.promptText = prompt;
+        this.firstPrompt = prompt;
 	}
+
+    public void CyclePrompt()
+    {
+        
+        if (isCyclic && !string.IsNullOrEmpty(this.secondPrompt.Trim()) && !string.IsNullOrEmpty(this.firstPrompt.Trim()))
+        {
+            if (curPrompt == FIRST_PROMPT)
+            {
+                curPrompt = SECOND_PROMPT;
+            }
+            else
+            {
+                curPrompt = FIRST_PROMPT;
+            }
+        }
+    }
 
 }
 

--- a/Project/Assets/Prairie/Framework/Script/Interaction/PromptInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/PromptInteraction.cs
@@ -23,7 +23,7 @@ public abstract class PromptInteraction : Interaction
     public void Reset()
     {
         Prompt prompt = this.gameObject.GetComponent<Prompt>();
-        if (prompt.promptText == null || prompt.promptText == "")
+        if (prompt.firstPrompt == null || prompt.firstPrompt == "")
         {
             prompt.SetDefaultPrompt();
         }


### PR DESCRIPTION
Adds cyclic prompts, allowing for up to two cycling prompts to be used. 

If the first prompt is left empty, no prompt will be used. If the second prompt is left empty it will be ignored.