### PR TITLE
Remove null-reference errors from editor lists

### DIFF
--- a/Project/Assets/Editor/CustomInspectors/ComponentToggleInteractionEditor.cs
+++ b/Project/Assets/Editor/CustomInspectors/ComponentToggleInteractionEditor.cs
@@ -1,25 +1,35 @@
 ﻿using UnityEngine;
+using System.Collections.Generic;
+using System.Collections;
 using UnityEditor;
 
 [CustomEditor(typeof(ComponentToggleInteraction))]
 public class ComponentToggleInteractionEditor : Editor {
 
 	ComponentToggleInteraction componentToggle;
+    Behaviour[] editorTargetList = new Behaviour[0];
 
 	public override void OnInspectorGUI ()
 	{
-		this.componentToggle = (ComponentToggleInteraction)target;
+        this.componentToggle = (ComponentToggleInteraction)target;
+
+        if (editorTargetList.Length == 0)
+        {
+            editorTargetList = componentToggle.target;
+        }
 
 		componentToggle.repeatable = EditorGUILayout.Toggle ("Repeatable?", componentToggle.repeatable);
-		componentToggle.target = PrairieGUI.drawObjectList<Behaviour> ("Behaviours To Toggle:", componentToggle.target);
+		editorTargetList = PrairieGUI.drawObjectList<Behaviour> ("Behaviours To Toggle:", editorTargetList);
 
+        componentToggle.target = PrairieGUI.RemoveNulls(editorTargetList);
 		this.DrawWarnings();
-		if (GUI.changed) {
+
+        if (GUI.changed) {
 			EditorUtility.SetDirty(componentToggle);
 		}
 	}
 
-	public void DrawWarnings()
+    public void DrawWarnings()
 	{
 		foreach (Behaviour behaviour in componentToggle.target) 
 		{

--- a/Project/Assets/Editor/CustomInspectors/SlideshowEditor.cs
+++ b/Project/Assets/Editor/CustomInspectors/SlideshowEditor.cs
@@ -6,11 +6,18 @@ using UnityEditor;
 public class SlideshowEditor : Editor {
 
 	Slideshow slideshow;
+    Texture2D[] editorSlides = new Texture2D[0];
 
 	public override void OnInspectorGUI()
 	{
 		slideshow = (Slideshow)target;
-		slideshow.Slides = PrairieGUI.drawObjectList ("Slides", slideshow.Slides);
+
+        if (editorSlides.Length == 0)
+        {
+            editorSlides = slideshow.Slides;
+        }
+
+		editorSlides = PrairieGUI.drawObjectList ("Slides", editorSlides);
 
 		for (int i = 0; i < slideshow.Slides.Length; i++) 
 		{
@@ -20,6 +27,8 @@ public class SlideshowEditor : Editor {
 				break;
 			}
 		}
+
+        slideshow.Slides = PrairieGUI.RemoveNulls(editorSlides);
 
 		if (GUI.changed) {
 			EditorUtility.SetDirty(slideshow);

--- a/Project/Assets/Editor/CustomInspectors/TriggerInteractionEditor.cs
+++ b/Project/Assets/Editor/CustomInspectors/TriggerInteractionEditor.cs
@@ -5,17 +5,25 @@ using UnityEditor;
 public class TriggerInteractionEditor : Editor {
 
 	TriggerInteraction trigger;
+    GameObject[] editorTriggeredObjects = new GameObject[0];
 
 	public override void OnInspectorGUI ()
 	{
 		this.trigger = (TriggerInteraction)target;
 
+        if (editorTriggeredObjects.Length == 0)
+        {
+            editorTriggeredObjects = trigger.triggeredObjects;
+        }
+
 		// Principle Configuration:
 		trigger.repeatable = EditorGUILayout.Toggle ("Repeatable?", trigger.repeatable);
 		trigger.triggeredObjects = PrairieGUI.drawObjectList<GameObject> ("Trigger Objects:", trigger.triggeredObjects);
 
-		// Warnings:
-		this.DrawWarnings();
+        trigger.triggeredObjects = PrairieGUI.RemoveNulls(editorTriggeredObjects);
+
+        // Warnings:
+        this.DrawWarnings();
 		if (GUI.changed) {
 			EditorUtility.SetDirty(trigger);
 		}

--- a/Project/Assets/Editor/CustomInspectors/TwineNodeEditor.cs
+++ b/Project/Assets/Editor/CustomInspectors/TwineNodeEditor.cs
@@ -7,16 +7,24 @@ using System.Linq;
 [CustomEditor(typeof(TwineNode))]
 public class TwineNodeEditor : Editor {
 
-
 	TwineNode node;
+    GameObject[] editorTriggeredObjects = new GameObject[0];
 
-	public override void OnInspectorGUI ()
+    public override void OnInspectorGUI ()
 	{
 		node = (TwineNode)target;
 
-		node.isDecisionNode = EditorGUILayout.Toggle ("Decision node?", node.isDecisionNode);
-		node.objectsToTrigger = PrairieGUI.drawObjectList ("Objects To Trigger", node.objectsToTrigger);
-		EditorGUILayout.LabelField ("Name", node.name);
+        if (editorTriggeredObjects.Length == 0)
+        {
+            editorTriggeredObjects = node.objectsToTrigger;
+        }
+
+        node.isDecisionNode = EditorGUILayout.Toggle ("Decision node?", node.isDecisionNode);
+        editorTriggeredObjects = PrairieGUI.drawObjectList ("Objects To Trigger", editorTriggeredObjects);
+
+        node.objectsToTrigger = PrairieGUI.RemoveNulls(editorTriggeredObjects);
+
+        EditorGUILayout.LabelField ("Name", node.name);
 		EditorGUILayout.LabelField ("Content");
 		EditorGUI.indentLevel += 1;
 		node.content = EditorGUILayout.TextArea (node.content);

--- a/Project/Assets/Editor/Utilities/PrairieGUI.cs
+++ b/Project/Assets/Editor/Utilities/PrairieGUI.cs
@@ -76,8 +76,7 @@ public class PrairieGUI {
 			list.Add (default(T));
 		}
 		EditorGUI.indentLevel -= 1;
-
-		return (T[])list.ToArray ();
+        return (T[])list.ToArray ();
 	}
 
 	public static T[] drawPrimitiveList <T> (string title, T[] array) where T : IConvertible
@@ -123,7 +122,7 @@ public class PrairieGUI {
 			list.Add (default(T));
 		}
 		EditorGUI.indentLevel -= 1;
-		return (T[])list.ToArray ();
+        return (T[])list.ToArray ();
 	}
 
 	public static List<int> drawTwineNodeDropdownList (string listTitle, string itemTitle, TwineNode[] nodes, List<int> selectedIndices)
@@ -160,4 +159,23 @@ public class PrairieGUI {
 
 		return selectedIndices;
 	}
+
+    /// <summary>
+    /// Removes all null values from an array
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="array"></param>
+    /// <returns></returns>
+    public static T[] RemoveNulls<T>(T[] array) where T : UnityEngine.Object
+    {
+        List<T> list = new List<T>();
+        foreach (T item in array)
+        {
+            if (item != null)
+            {
+                list.Add(item);
+            }
+        }
+        return list.ToArray();
+    }
 }

--- a/Project/Assets/Prairie/Framework/Script/Interaction/ComponentToggleInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/ComponentToggleInteraction.cs
@@ -5,8 +5,9 @@ using System.Collections;
 public class ComponentToggleInteraction : PromptInteraction 
 {
 	public Behaviour[] target = new Behaviour[0];
+    public Behaviour[] editorTargetList = new Behaviour[0]; //used for the editor
 
-	void OnDrawGizmosSelected()
+    void OnDrawGizmosSelected()
 	{
 		Gizmos.color = Color.red;
 		for (int i = 0; i < target.Length; i++)


### PR DESCRIPTION
This PR is addressing issue #144 

A method as been added to PrairieGUI that removes any null values from an array. 

When a custom editor wants to use our custom-list-drawing method, instead of writing directly to the object's array, instead there should be an intermediate variable in the editor script to store the value. Then any null values should be removed before passing that value back to the object. This allows the editor to have empty spaces to be drawn, but prevents those null values from being pushed back to the object and causing errors. 

To make sure that the editor list is not empty when reloading (say after testing the game) a quick check at the beginning of OnInspectorGUI needs to be done to see if the array is currently empty, and if it is set it to the value of the object's array.


This seems a little complicated, but it is necessary to work around the set size of arrays.