### PR TITLE
If only one twine prompt, use simpler GUI

### DIFF
--- a/Project/Assets/Editor/CustomInspectors/PromptEditor.cs
+++ b/Project/Assets/Editor/CustomInspectors/PromptEditor.cs
@@ -74,6 +74,8 @@ public class PromptEditor : Editor {
             return;
         }
 
+        EditorGUILayout.LabelField ("Twine Prompts:");
+
         // build dictionary and get a value for each key
         foreach (string nodeName in twineNodeNames)
         {

--- a/Project/Assets/Editor/CustomInspectors/PromptEditor.cs
+++ b/Project/Assets/Editor/CustomInspectors/PromptEditor.cs
@@ -26,7 +26,7 @@ public class PromptEditor : Editor {
 		}
 	}
 
-    public void SimplePromptGUI()
+    public void SimplePromptGUI(bool cyclicAllowed = true)
     {
         GUIContent label = new GUIContent ("Prompt Text", "Text displayed when a player can interact with this object.");
         prompt.firstPrompt = EditorGUILayout.TextField (label, prompt.firstPrompt);
@@ -34,28 +34,26 @@ public class PromptEditor : Editor {
         if (string.IsNullOrEmpty(prompt.firstPrompt.Trim()))
         {
             PrairieGUI.hintLabel("No prompt will be displayed in game.");
+            prompt.isCyclic = false;    // don't allow for a cycle if the first prompt is empty
+            return;
         }
-		else
-        {
-            GUIContent cyclicLabel = new GUIContent("Cyclic Prompt", "Does this prompt have two cycling values? (i.e. open, close)");
-            prompt.isCyclic = EditorGUILayout.Toggle(cyclicLabel, prompt.isCyclic);
-            if (prompt.isCyclic)
-            {
+        if (!cyclicAllowed) { return; } // guard statement
 
-                GUIContent secondLabel = new GUIContent("Second Prompt", "Second prompt to display, will toggle between this and first prompt.");
-                prompt.secondPrompt = EditorGUILayout.TextField(secondLabel, prompt.secondPrompt);
-                if (string.IsNullOrEmpty(prompt.secondPrompt.Trim()))
-                {
-                    PrairieGUI.hintLabel("Second prompt will be ignored.");
-                }
+        GUIContent cyclicLabel = new GUIContent("Cyclic Prompt", "Does this prompt have two cycling values? (i.e. open, close)");
+        prompt.isCyclic = EditorGUILayout.Toggle(cyclicLabel, prompt.isCyclic);
+        if (prompt.isCyclic)
+        {
+            GUIContent secondLabel = new GUIContent("Second Prompt", "Second prompt to display, will toggle between this and first prompt.");
+            prompt.secondPrompt = EditorGUILayout.TextField(secondLabel, prompt.secondPrompt);
+            if (string.IsNullOrEmpty(prompt.secondPrompt.Trim()))
+            {
+                PrairieGUI.hintLabel("Second prompt will be ignored.");
             }
         }
     }
 
     public void TwinePromptGUI()
     {
-		EditorGUILayout.LabelField ("Twine Prompts:");
-
         // get list of twine nodes we need prompts for, the keys of our dictionary
         AssociatedTwineNodes associatedNodes = this.prompt.gameObject.GetComponent<AssociatedTwineNodes> ();
         List<string> twineNodeNames = new List<string> ();
@@ -63,6 +61,17 @@ public class PromptEditor : Editor {
         {
             TwineNode twineNode = twineNodeObject.GetComponent<TwineNode> ();
             twineNodeNames.Add(twineNode.name);
+        }
+
+        // special case: if only one twine node - use the basic input
+        if (twineNodeNames.Count == 1)
+        {
+            // use the simple prompt GUI without allowing for cycles
+            SimplePromptGUI(cyclicAllowed: false);
+            // bind the result from simple GUI back to the twine based key
+            prompt.twinePrompts.Set(twineNodeNames[0], prompt.firstPrompt);
+            // do not fall through into the dictionary input
+            return;
         }
 
         // build dictionary and get a value for each key


### PR DESCRIPTION
This PR introduces a minor UX improvement. When there is only a single associated twine node, a basic prompt GUI is used.

> Additionally, this PR fixes a bug in which a prompt could be mistakenly configured to be cyclic with a blank initial prompt, but a full second prompt, and the GUI would hide the second prompt. Now, such a situation is not possible.

### Implementation Notes
- Outsources the GUI on this special case to the same function we use to show the default (non-twine) GUI sans the cyclical option.
    - this has an added benefit of syncing the twine node prompt w/ the `firstPrompt` value, so if the twine node is removed, the prompt remains the same.
- Uses same backend dictionary to maintain twine prompt based features (such as automatic hiding when there is no active twine node parent).