### PR TITLE
Much simpler iteration of fixing null errors

### DIFF
--- a/Project/Assets/Editor/CustomInspectors/TriggerInteractionEditor.cs
+++ b/Project/Assets/Editor/CustomInspectors/TriggerInteractionEditor.cs
@@ -23,21 +23,38 @@ public class TriggerInteractionEditor : Editor {
 
 	public void DrawWarnings()
 	{
+        ///run each of these as a separate loop, because we don't want the label to show up more than once for the first two, 
+        ///but we want both to show if they both are triggered (for instance if the first object is empty, and the second refers to itself
+        /// The last loop is also separate so that it can be run for every object that might not have an interaction on it
 		foreach (GameObject triggerTarget in trigger.triggeredObjects)
 		{
-			if (triggerTarget.GetComponent<Interaction>() == null)
-			{
-				// no interaction attached to this trigger target!
-				string targetName = triggerTarget.name;
-				PrairieGUI.warningLabel("'" + targetName + "' has no interactions attached to it. Triggering it will do nothing.");
-			}
-
-			if (triggerTarget == this.trigger.gameObject)
-			{
-				// warn users about INFINITE triggering
-				PrairieGUI.warningLabel("A trigger interaction should not trigger itself!");
-			}
+            if (triggerTarget == null)
+            {
+                PrairieGUI.warningLabel("You have one or more empty slots in your list of toggles.  Please fill these slots or remove them.");
+                break;
+            }
 		}
-	}
+
+        foreach (GameObject triggerTarget in trigger.triggeredObjects)
+        {
+            if (triggerTarget == this.trigger.gameObject)
+            {
+                // warn users about INFINITE triggering
+                PrairieGUI.warningLabel("A trigger interaction should not trigger itself!");
+                break;
+            }
+        }
+
+        foreach (GameObject triggerTarget in trigger.triggeredObjects)
+        {
+            if (triggerTarget != null && triggerTarget.GetComponent<Interaction>() == null)
+            {
+                // no interaction attached to this trigger target!
+                string targetName = triggerTarget.name;
+                PrairieGUI.warningLabel("'" + targetName + "' has no interactions attached to it. Triggering it will do nothing.");
+            }
+        }
+
+    }
 
 }

--- a/Project/Assets/Prairie/Framework/Script/Interaction/ComponentToggleInteraction.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/ComponentToggleInteraction.cs
@@ -12,7 +12,11 @@ public class ComponentToggleInteraction : PromptInteraction
 		for (int i = 0; i < target.Length; i++)
 		{
 			// Draw red line(s) between the object and the objects whose Behaviours it toggles
-			Gizmos.DrawLine(transform.position, target[i].transform.position);
+            if (target[i] != null)
+            {
+                Gizmos.DrawLine(transform.position, target[i].transform.position);
+            }
+			
 		}
 	}
 


### PR DESCRIPTION
Null errors were possible in component toggle and trigger interaction. I also realized that a fix was unnecessary for associated twine node, as it always puts in a default value.