### PR TITLE
Slideshow to Interaction

### DIFF
--- a/Project/Assets/Prairie/Framework/Script/Interaction/FirstPersonInteractor.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/FirstPersonInteractor.cs
@@ -143,11 +143,11 @@ public class FirstPersonInteractor : MonoBehaviour
 	public void OnTriggerEnter(Collider other)
 	{
 		GameObject inside = other.gameObject;
-		// automatically trigger area we're now inside of's NON-ANNOTATION interactions
+		// automatically trigger area we're now inside of's interactions
 		List<Interaction> toTrigger = new List<Interaction>();
 		foreach (Interaction i in inside.GetComponents<Interaction> ())
 		{
-			if (!(i is Annotation || i is Slideshow))
+			if (!(i is Annotation))
 			{
 				i.Interact (this.gameObject);
 			}
@@ -164,7 +164,7 @@ public class FirstPersonInteractor : MonoBehaviour
 		
 		foreach (Interaction i in this.highlightedObject.GetComponents<Interaction> ())
 		{
-			if (i is Annotation || i is Slideshow)
+			if (i is Annotation)
 			{
 				// special cases, handled by `AttemptReadAnnotation`
 				continue;
@@ -191,7 +191,7 @@ public class FirstPersonInteractor : MonoBehaviour
 
 		foreach (Interaction i in this.highlightedObject.GetComponents<Interaction> ()) 
 		{
-			if (i.enabled && (i is Annotation || i is Slideshow))
+			if (i.enabled && (i is Annotation))
 			{
 				i.Interact (this.gameObject);
 			}

--- a/Project/Assets/Prairie/Framework/Script/Interaction/FirstPersonInteractor.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/FirstPersonInteractor.cs
@@ -191,7 +191,7 @@ public class FirstPersonInteractor : MonoBehaviour
 
 		foreach (Interaction i in this.highlightedObject.GetComponents<Interaction> ()) 
 		{
-			if (i.enabled && (i is Annotation))
+			if (i is Annotation)
 			{
 				i.Interact (this.gameObject);
 			}

--- a/Project/Assets/Prairie/Framework/Script/Interaction/Slideshow.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/Slideshow.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using System.Collections;
 
-[AddComponentMenu("Prairie/Annotation/Slideshow")]
+[AddComponentMenu("Prairie/Interactions/Slideshow")]
 public class Slideshow : PromptInteraction
 {
 	private bool Active = false;


### PR DESCRIPTION
Slideshows are now treated as other standard interactions (and not as Annotations).

> Additionally fixed a redundant check on `.enabled` for an Interaction (the `Interact()` method handles this case).