### PR TITLE
Removed TwineNode Gizmos

### DIFF
--- a/Project/Assets/Prairie/Framework/Script/Interaction/AssociatedTwineNodes.cs
+++ b/Project/Assets/Prairie/Framework/Script/Interaction/AssociatedTwineNodes.cs
@@ -24,15 +24,6 @@ public class AssociatedTwineNodes : PromptInteraction
 		}
 	}
 
-	void OnDrawGizmosSelected()
-	{
-		// Draw a green line between a Twine node and its subsequent Twine nodes
-		Gizmos.color = Color.green;
-		foreach (GameObject twineNodeObject in associatedTwineNodeObjects) {
-			Gizmos.DrawLine (transform.position, twineNodeObject.transform.position);
-		}
-	}
-
 	protected override void PerformAction () 
 	{
 		foreach (GameObject twineNodeObject in associatedTwineNodeObjects) {

--- a/Project/Assets/Prairie/Framework/Script/Twine/TwineNode.cs
+++ b/Project/Assets/Prairie/Framework/Script/Twine/TwineNode.cs
@@ -192,31 +192,4 @@ public class TwineNode : MonoBehaviour {
 			parent.GetComponent<TwineNode> ().Deactivate ();
 		}
 	}
-
-	// GIZMOS
-
-	void OnDrawGizmos()
-	{
-		Gizmos.color = Color.black;
-		foreach (GameObject child in this.children)
-		{
-			Gizmos.DrawLine(transform.position, child.transform.position);
-		}
-
-		Gizmos.color = Color.gray;
-
-		// TODO: draw text and such...
-		// 		 just mark position with a sphere for now...
-		Gizmos.DrawSphere(transform.position, 0.1f);
-	}
-
-	void OnDrawGizmosSelected()
-	{
-		Gizmos.color = Color.cyan;
-		foreach (GameObject gameObject in objectsToTrigger)
-		{
-			// Draw cyan line(s) between the current Twine node and the object(s) it triggers
-			Gizmos.DrawLine(transform.position, gameObject.transform.position);
-		}
-	}
 }


### PR DESCRIPTION
From issue #167:
> The solution posed in issue #55 was deemed unfeasible. We decided to scratch the TwineNode gizmo due to other factors as well (see also: Twine spaghetti on Slack).

This PR removes all gizmos which reference the physical space of TwineNodes, as well as the importer's functions which place `TwineNodes` in Unity space based on their Twine graph locations.